### PR TITLE
LRQA-36161 remove invalid property syntax

### DIFF
--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -1145,12 +1145,6 @@ public class PoshiRunnerContext {
 
 			sb.append(_getTestBatchGroups());
 		}
-		else {
-			sb.append("Test case method names: ");
-			sb.append("=");
-			sb.append(PropsValues.TEST_NAME);
-			sb.append("\n");
-		}
 
 		FileUtil.write("test.case.method.names.properties", sb.toString());
 	}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -460,7 +460,7 @@ public class PoshiRunnerContext {
 			propertyQuery = sb.toString();
 		}
 
-		List<String> classCommandNames = new ArrayList<>();
+		List<String> namespacedClassCommandNames = new ArrayList<>();
 
 		PQLEntity pqlEntity = PQLEntityFactory.newPQLEntity(propertyQuery);
 
@@ -475,20 +475,22 @@ public class PoshiRunnerContext {
 				properties);
 
 			if (pqlResultBoolean) {
-				classCommandNames.add(testCaseNamespacedClassCommandName);
+				namespacedClassCommandNames.add(
+					testCaseNamespacedClassCommandName);
 			}
 		}
 
 		System.out.println(
-			"The following query returned " + classCommandNames.size() +
-				" test class command names:");
+			"The following query returned " +
+				namespacedClassCommandNames.size() +
+					" test class command names:");
 		System.out.println(propertyQuery);
 
 		if (PropsValues.TEST_BATCH_RUN_TYPE.equals("sequential")) {
-			return _getTestBatchSequentialGroups(classCommandNames);
+			return _getTestBatchSequentialGroups(namespacedClassCommandNames);
 		}
 		else if (PropsValues.TEST_BATCH_RUN_TYPE.equals("single")) {
-			return _getTestBatchSingleGroups(classCommandNames);
+			return _getTestBatchSingleGroups(namespacedClassCommandNames);
 		}
 
 		throw new Exception(
@@ -496,16 +498,17 @@ public class PoshiRunnerContext {
 	}
 
 	private static String _getTestBatchSequentialGroups(
-			List<String> classCommandNames)
+			List<String> namespacedClassCommandNames)
 		throws Exception {
 
 		Multimap<Properties, String> multimap = HashMultimap.create();
 
-		for (String classCommandName : classCommandNames) {
+		for (String namespacedClassCommandName : namespacedClassCommandNames) {
 			Properties properties = new Properties();
 
 			properties.putAll(
-				_namespacedClassCommandNamePropertiesMap.get(classCommandName));
+				_namespacedClassCommandNamePropertiesMap.get(
+					namespacedClassCommandName));
 
 			if (Validator.isNotNull(
 					PropsValues.TEST_BATCH_GROUP_IGNORE_REGEX)) {
@@ -521,12 +524,7 @@ public class PoshiRunnerContext {
 				}
 			}
 
-			String simpleClassCommandName =
-				PoshiRunnerGetterUtil.
-					getClassCommandNameFromNamespacedClassCommandName(
-						classCommandName);
-
-			multimap.put(properties, simpleClassCommandName);
+			multimap.put(properties, namespacedClassCommandName);
 		}
 
 		Map<Integer, List<String>> classCommandNameGroups = new HashMap<>();
@@ -614,23 +612,14 @@ public class PoshiRunnerContext {
 	}
 
 	private static String _getTestBatchSingleGroups(
-		List<String> classCommandNames) {
+		List<String> namespacedClassCommandNames) {
 
 		StringBuilder sb = new StringBuilder();
 
 		int groupSize = 15;
 
-		List<String> simpleClassCommandNames = new ArrayList<>();
-
-		for (String classCommandName : classCommandNames) {
-			simpleClassCommandNames.add(
-				PoshiRunnerGetterUtil.
-					getClassCommandNameFromNamespacedClassCommandName(
-						classCommandName));
-		}
-
 		List<List<String>> partitions = Lists.partition(
-			simpleClassCommandNames, groupSize);
+			namespacedClassCommandNames, groupSize);
 
 		for (int i = 0; i < partitions.size(); i++) {
 			sb.append("RUN_TEST_CASE_METHOD_GROUP_");

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeSet;
 
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -693,8 +692,6 @@ public class PoshiRunnerContext {
 				continue;
 			}
 
-			String componentName = rootElement.attributeValue("component-name");
-
 			if (rootElement.attributeValue("extends") != null) {
 				String extendsTestCaseClassName = rootElement.attributeValue(
 					"extends");
@@ -1149,19 +1146,10 @@ public class PoshiRunnerContext {
 			sb.append(_getTestBatchGroups());
 		}
 		else {
-			for (String componentName : _componentNames) {
-				String componentNameKey =
-					componentName + "_TEST_CASE_METHOD_NAMES";
-
-				componentNameKey = StringUtil.upperCase(
-					componentNameKey.replace("-", "_"));
-
-				sb.append(componentNameKey);
-
-				sb.append("=");
-				sb.append(PropsValues.TEST_NAME);
-				sb.append("\n");
-			}
+			sb.append("Test case method names: ");
+			sb.append("=");
+			sb.append(PropsValues.TEST_NAME);
+			sb.append("\n");
 		}
 
 		FileUtil.write("test.case.method.names.properties", sb.toString());
@@ -1211,7 +1199,6 @@ public class PoshiRunnerContext {
 		new HashMap<>();
 	private static final Map<String, String> _commandSummaries =
 		new HashMap<>();
-	private static final Set<String> _componentNames = new TreeSet<>();
 	private static final Map<String, String> _filePaths = new HashMap<>();
 	private static final Map<String, Integer> _functionLocatorCounts =
 		new HashMap<>();
@@ -1220,7 +1207,6 @@ public class PoshiRunnerContext {
 	private static final List<String> _namespaces = new ArrayList<>();
 	private static final Map<String, String> _pathExtensions = new HashMap<>();
 	private static final Map<String, String> _pathLocators = new HashMap<>();
-	private static final List<String> _productNames = new ArrayList<>();
 	private static final List<URL> _resourceURLs = new ArrayList<>();
 	private static final Map<String, Element> _rootElements = new HashMap<>();
 	private static final Map<String, Integer> _seleniumParameterCounts =
@@ -1241,17 +1227,6 @@ public class PoshiRunnerContext {
 		new SimpleDateFormat("YYYY-MM-dd");
 
 	static {
-		Collections.addAll(
-			_componentNames, StringUtil.split(PropsValues.COMPONENT_NAMES));
-
-		Collections.addAll(
-			_productNames, StringUtil.split(PropsValues.PRODUCT_NAMES));
-
-		for (String productName : _productNames) {
-			_componentNames.add(productName);
-			_componentNames.add(productName + "-known-issues");
-		}
-
 		String testCaseAvailablePropertyNames =
 			PropsValues.TEST_CASE_AVAILABLE_PROPERTY_NAMES;
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -105,10 +105,12 @@ public class PoshiRunnerGetterUtil {
 				return className + "#" + commandName;
 			}
 
-			return matcher.group("className");
+			return className;
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find class name and/or command name in " +
+				namespacedClassCommandName);
 	}
 
 	public static String getClassNameFromFilePath(String filePath) {
@@ -132,7 +134,8 @@ public class PoshiRunnerGetterUtil {
 			return matcher.group("className");
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find class name in " + namespacedClassCommandName);
 	}
 
 	public static String getClassNameFromNamespacedClassName(
@@ -145,7 +148,8 @@ public class PoshiRunnerGetterUtil {
 			return matcher.group("className");
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find class name in " + namespacedClassName);
 	}
 
 	public static String getClassTypeFromFileExtension(String fileExtension) {
@@ -180,7 +184,8 @@ public class PoshiRunnerGetterUtil {
 			return commandName;
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find command name in " + namespacedClassCommandName);
 	}
 
 	public static String getExtendedTestCaseName() {
@@ -291,7 +296,8 @@ public class PoshiRunnerGetterUtil {
 			return namespace + "." + className;
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find class name in " + namespacedClassCommandName);
 	}
 
 	public static String getNamespaceFromNamespacedClassCommandName(
@@ -310,7 +316,8 @@ public class PoshiRunnerGetterUtil {
 			return namespace;
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find namespace in " + namespacedClassCommandName);
 	}
 
 	public static String getNamespaceFromNamespacedClassName(
@@ -329,7 +336,8 @@ public class PoshiRunnerGetterUtil {
 			return namespace;
 		}
 
-		throw new RuntimeException();
+		throw new RuntimeException(
+			"Unable to find namespace in " + namespaceClassName);
 	}
 
 	public static String getProjectDirName() {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -321,10 +321,10 @@ public class PoshiRunnerGetterUtil {
 	}
 
 	public static String getNamespaceFromNamespacedClassName(
-		String namespaceClassName) {
+		String namespacedClassName) {
 
 		Matcher matcher = _namespacedClassCommandNamePattern.matcher(
-			namespaceClassName);
+			namespacedClassName);
 
 		if (matcher.find()) {
 			String namespace = matcher.group("namespace");
@@ -337,7 +337,7 @@ public class PoshiRunnerGetterUtil {
 		}
 
 		throw new RuntimeException(
-			"Unable to find namespace in " + namespaceClassName);
+			"Unable to find namespace in " + namespacedClassName);
 	}
 
 	public static String getProjectDirName() {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/XMLLoggerHandler.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/XMLLoggerHandler.java
@@ -616,22 +616,22 @@ public final class XMLLoggerHandler {
 	}
 
 	private static LoggerElement _getMacroCommandLoggerElement(
-			String classCommandName)
+			String namespacedClassCommandName)
 		throws Exception {
 
-		String simpleClassCommandName =
+		String classCommandName =
 			PoshiRunnerGetterUtil.
 				getClassCommandNameFromNamespacedClassCommandName(
-					classCommandName);
+					namespacedClassCommandName);
 		String namespace = PoshiRunnerStackTraceUtil.getCurrentNamespace(
-			classCommandName);
+			namespacedClassCommandName);
 
 		Element commandElement = PoshiRunnerContext.getMacroCommandElement(
-			simpleClassCommandName, namespace);
+			classCommandName, namespace);
 
 		String className =
 			PoshiRunnerGetterUtil.getClassNameFromNamespacedClassCommandName(
-				simpleClassCommandName);
+				namespacedClassCommandName);
 
 		Element rootElement = PoshiRunnerContext.getMacroRootElement(
 			className, namespace);


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-36161

This commit mitigates the problem with sending test results to testray, the testcases will have namespace in their names when they appear on testray:

https://github.com/yichenroy/com-liferay-poshi-runner/commit/63d43d81c6ebfee13d4b97be2d07ae206d07f784