### PR TITLE
LRQA-40447 PoshiElement translation: Additional parser fixes

### DIFF
--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -271,7 +271,7 @@ public class CommandPoshiElement extends PoshiElement {
 	}
 
 	protected boolean isCDATAVar(String readableSyntax) {
-		if (readableSyntax.contains("escapeText(")) {
+		if (readableSyntax.contains("\'\'\'")) {
 			return true;
 		}
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -122,6 +122,10 @@ public class ExecutePoshiElement extends PoshiElement {
 				continue;
 			}
 
+			if (assignment.endsWith(",")) {
+				assignment = assignment.substring(0, assignment.length() - 1);
+			}
+
 			assignment = "var " + assignment + ";";
 
 			add(PoshiNodeFactory.newPoshiNode(this, assignment));

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
@@ -51,17 +51,16 @@ public class ForPoshiElement extends PoshiElement {
 				String parentheticalContent = getParentheticalContent(
 					readableBlock);
 
-				String[] parentheticalContentArray = parentheticalContent.split(
-					":");
+				int index = parentheticalContent.indexOf(":");
 
-				String param = parentheticalContentArray[0].trim();
+				String param = parentheticalContent.substring(0, index);
 
-				addAttribute("param", param);
+				addAttribute("param", param.trim());
 
 				String list = getQuotedContent(
-					parentheticalContentArray[1].trim());
+					parentheticalContent.substring(index + 1));
 
-				addAttribute("list", list);
+				addAttribute("list", list.trim());
 
 				continue;
 			}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
@@ -47,7 +47,8 @@ public class ForPoshiElement extends PoshiElement {
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
 		for (String readableBlock : getReadableBlocks(readableSyntax)) {
-			if (readableBlock.startsWith("for (")) {
+			if (readableBlock.startsWith("for (") &&
+				!readableBlock.endsWith("}")) {
 				String parentheticalContent = getParentheticalContent(
 					readableBlock);
 
@@ -114,7 +115,9 @@ public class ForPoshiElement extends PoshiElement {
 		for (String line : readableSyntax.split("\n")) {
 			String trimmedLine = line.trim();
 
-			if (trimmedLine.startsWith("for (")) {
+			if (readableSyntax.startsWith(line) &&
+				trimmedLine.startsWith("for (")) {
+
 				readableBlocks.add(line);
 
 				continue;

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
@@ -49,6 +49,7 @@ public class ForPoshiElement extends PoshiElement {
 		for (String readableBlock : getReadableBlocks(readableSyntax)) {
 			if (readableBlock.startsWith("for (") &&
 				!readableBlock.endsWith("}")) {
+
 				String parentheticalContent = getParentheticalContent(
 					readableBlock);
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
@@ -120,7 +120,9 @@ public class ForPoshiElement extends PoshiElement {
 				continue;
 			}
 
-			if (!trimmedLine.startsWith("else {")) {
+			if (!trimmedLine.startsWith("else if (") &&
+				!trimmedLine.startsWith("else {")) {
+
 				String readableBlock = sb.toString();
 
 				readableBlock = readableBlock.trim();

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -181,6 +181,10 @@ public abstract class PoshiElement
 		return RegexUtil.getGroup(readableSyntax, ".*?\"(.*)\"", 1);
 	}
 
+	protected String getReadableEscapedContent(String readableSyntax) {
+		return RegexUtil.getGroup(readableSyntax, ".*?\'\'\'(.*?)\'\'\'", 1);
+	}
+
 	protected String getValueFromAssignment(String assignment) {
 		int start = assignment.indexOf("=");
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -274,7 +274,8 @@ public abstract class PoshiElement
 		if (readableSyntax.startsWith("property") ||
 			readableSyntax.startsWith("var")) {
 
-			if (readableSyntax.endsWith("\";") ||
+			if (readableSyntax.endsWith("\'\'\';") ||
+				readableSyntax.endsWith("\";") ||
 				readableSyntax.endsWith(");")) {
 
 				return true;
@@ -330,8 +331,7 @@ public abstract class PoshiElement
 	}
 
 	protected static final Pattern nestedVarAssignmentPattern = Pattern.compile(
-		"(\\w*? = \".*?\"|\\w*? = escapeText\\(\".*?\"\\))($|\\s|,)",
-		Pattern.DOTALL);
+		"(\\w*? = \".*?\"|\\w*? = \'\'\'.*?\'\'\')($|\\s|,)", Pattern.DOTALL);
 
 	private void _addAttributes(Element element) {
 		for (Attribute attribute :

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -182,13 +182,23 @@ public abstract class PoshiElement
 	}
 
 	protected String getReadableEscapedContent(String readableSyntax) {
-		return RegexUtil.getGroup(readableSyntax, ".*?\'\'\'(.*?)\'\'\'", 1);
+		readableSyntax = readableSyntax.trim();
+
+		return readableSyntax.substring(3, readableSyntax.length() - 3);
 	}
 
 	protected String getValueFromAssignment(String assignment) {
+		assignment = assignment.trim();
+
 		int start = assignment.indexOf("=");
 
-		String value = assignment.substring(start + 1);
+		int end = assignment.length();
+
+		if (assignment.endsWith(";")) {
+			end = end - 1;
+		}
+
+		String value = assignment.substring(start + 1, end);
 
 		return value.trim();
 	}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -194,6 +194,10 @@ public abstract class PoshiElement
 	}
 
 	protected boolean isBalancedReadableSyntax(String readableSyntax) {
+		readableSyntax = readableSyntax.replaceAll("<!--.*?-->", "");
+
+		readableSyntax = readableSyntax.replaceAll("\'\'\'.*?\'\'\'", "\"\"");
+
 		Stack<Character> stack = new Stack<>();
 
 		for (char c : readableSyntax.toCharArray()) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
@@ -54,9 +54,9 @@ public class VarPoshiElement extends PoshiElement {
 				if (node instanceof CDATA) {
 					StringBuilder sb = new StringBuilder();
 
-					sb.append("escapeText(\"");
+					sb.append("\'\'\'");
 					sb.append(node.getText());
-					sb.append("\")");
+					sb.append("\'\'\'");
 
 					return sb.toString();
 				}
@@ -72,15 +72,15 @@ public class VarPoshiElement extends PoshiElement {
 
 		addAttribute("name", name);
 
-		String quotedValue = getValueFromAssignment(readableSyntax);
+		String value = getValueFromAssignment(readableSyntax);
 
-		String value = getQuotedContent(quotedValue);
-
-		if (quotedValue.startsWith("escapeText(")) {
-			addCDATA(value);
+		if (value.startsWith("\'\'\'")) {
+			addCDATA(getReadableEscapedContent(value));
 
 			return;
 		}
+
+		value = getQuotedContent(value);
 
 		if (value.contains("Util.") || value.startsWith("selenium.")) {
 			if (value.startsWith("selenium.")) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
@@ -108,9 +108,7 @@ public class VarPoshiElement extends PoshiElement {
 
 		PoshiElement parentElement = (PoshiElement)getParent();
 
-		String parentElementName = parentElement.getName();
-
-		if (!parentElementName.equals("execute")) {
+		if (!(parentElement instanceof ExecutePoshiElement)) {
 			sb.append(getName());
 			sb.append(" ");
 		}
@@ -145,7 +143,7 @@ public class VarPoshiElement extends PoshiElement {
 
 		sb.append(value);
 
-		if (!parentElementName.equals("execute")) {
+		if (!(parentElement instanceof ExecutePoshiElement)) {
 			sb.append(";");
 		}
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -67,6 +67,12 @@
 
 					<!-- This is a comment -->
 				</then>
+				<elseif>
+					<isset var="duplicate" />
+					<then>
+						<echo message="Please enter a unique ID." />
+					</then>
+				</elseif>
 				<else>
 					<execute macro="Alert#viewSuccessMessage" />
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -56,6 +56,10 @@
 
 			<execute function="AssertTextEquals" locator1="Breadcrumb#BREADCRUMB_ENTRY" value1="${breadcrumbNameUppercase}" />
 
+			<for list="${breadcrumbListVisible}" param="breadcrumbName">
+				<execute function="AssertTextEquals" locator1="Breadcrumb#BREADCRUMB_ENTRY" value1="${breadcrumbNameUppercase}" />
+			</for>
+
 			<if>
 				<isset var="duplicate" />
 				<then>

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -210,6 +210,8 @@
 
 		<var name="testCDATA"><![CDATA['alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>]]></var>
 
+		<var name="testCDATA"><![CDATA[']]></var>
+
 		<var name="wikiPageContent"><![CDATA[<p id='demo'>PASS</p>
 
 <script type='text/javascript'>

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -240,7 +240,9 @@
 		<take-screenshot />
 
 		<while>
-			<condition function="IsElementPresent" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC" />
+			<condition function="IsElementPresent" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC">
+				<var name="key_userScreenName" value="ldapusercn" />
+			</condition>
 			<then>
 				<execute function="Click" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC" />
 			</then>

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -77,6 +77,10 @@
 			<!-- This is a comment -->
 		</for>
 
+		<for list="Breadcrumb: 1, Breadcrumb: 2" param="breadcrumbName">
+			<execute function="AssertTextEquals" locator1="Breadcrumb#BREADCRUMB_ENTRY" value1="${breadcrumbNameUppercase}" />
+		</for>
+
 		<execute macro="User#addCP">
 			<var name="userEmailAddress" value="${userEmailAddress}" />
 			<var name="userFirstName" value="${userFirstName}" />

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -69,6 +69,10 @@ definition {
 			// This is a comment
 		}
 
+		for (breadcrumbName : "Breadcrumb: 1, Breadcrumb: 2") {
+			AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
+		}
+
 		User.addCP(
 			userEmailAddress = "${userEmailAddress}",
 			userFirstName = "${userFirstName}",

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -54,6 +54,10 @@ definition {
 
 			AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
 
+			for (breadcrumbName : "${breadcrumbListVisible}") {
+				AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
+			}
+
 			if (isSet(duplicate)) {
 				Alert.viewErrorMessage(
 					errorMessage = "A configuration with this ID already exists. Please enter a unique ID."

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -188,7 +188,7 @@ definition {
 
 		takeScreenshot();
 
-		while (IsElementPresent(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC")) {
+		while (IsElementPresent(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC", key_userScreenName = "ldapusercn")) {
 			Click(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC");
 		}
 

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -62,6 +62,9 @@ definition {
 				echo("Please enter a unique ID.");
 				// This is a comment
 			}
+			else if (isSet(duplicate)) {
+				echo("Please enter a unique ID.");
+			}
 			else {
 				Alert.viewSuccessMessage();
 				// This is a comment

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -159,6 +159,7 @@ definition {
 			siteName
 		);
 		var testCDATA = ''''alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>''';
+		var testCDATA = ''''''';
 		var wikiPageContent = '''<p id='demo'>PASS</p>
 
 <script type='text/javascript'>

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -158,30 +158,30 @@ definition {
 			),
 			siteName
 		);
-		var testCDATA = escapeText("'alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>");
-		var wikiPageContent = escapeText("<p id='demo'>PASS</p>
+		var testCDATA = ''''alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>''';
+		var wikiPageContent = '''<p id='demo'>PASS</p>
 
 <script type='text/javascript'>
 	document.getElementById('demo').innerHTML = 'FAIL';
-</script>");
+</script>''';
 
 		AlloyEditor.addSourceContent(
-			content = escapeText("
+			content = '''
 <h2 class="text-center">Space Program 大学生涯教育</h2>
 
 <p class="text-center">地球から、宇宙の果てへ</p>
-")
+'''
 		);
 
 		KaleoDesigner.viewSourceXMLLine(
-			kdSourceXML = escapeText("<name>Timer Name</name>"),
+			kdSourceXML = '''<name>Timer Name</name>''',
 			line = "21"
 		);
 
 		User.editDetailsViaMyAccount(
-			userFirstNameEdit = escapeText("'alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>"),
-			userLastNameEdit = escapeText("<script>document.write("XSS"); window.stop();</script>"),
-			userMiddleNameEdit = escapeText("<script>document.write("XSS"); window.stop();</script>")
+			userFirstNameEdit = ''''alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>''',
+			userLastNameEdit = '''<script>document.write("XSS"); window.stop();</script>''',
+			userMiddleNameEdit = '''<script>document.write("XSS"); window.stop();</script>'''
 		);
 
 		Smoke.viewWelcomePage();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40447 
https://issues.liferay.com/browse/LRQA-40448
https://issues.liferay.com/browse/LRQA-40522

### Translation Status
#### At head: 
* 2213 / 2331 (94%) test commands were successfully translated
* 341 / 351 (97%) test files were successfully translated accounting for  2170 / 2331 (93%) test commands

#### With these changes:
* 2322 / 2331 (99%) test commands were successfully translated
* 346 / 351 (98%) test files were successfully translated accounting for  2309 / 2331 (99%) test commands

#### With these changes + additional syntax changes in the testcase files: 
* 2330 / 2331 (99%) test commands were successfully translated
* 350 / 351 (99%) test files were successfully translated accounting for  2329 / 2331 (99%) test commands

### Changes in this pull include:
* Bug fix: Poshiscript 'for' elements could not use ":" characters in the list
* Bug fix: 'else if' elements within 'for' elements were not being parsed to poshiscript correctly 
* Update: Use `'''` syntax instead of `escapeText("")` syntax for escaped text (CDATA equivalent)

@pyoo47, @michaelhashimoto, @brianchiu