### PR TITLE
LRQA-40617 Determine type of 'execute' element by a static list of function files and util classes

### DIFF
--- a/poshi-runner/bnd.bnd
+++ b/poshi-runner/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner
 Bundle-SymbolicName: com.liferay.poshi.runner
-Bundle-Version: 1.0.104
+Bundle-Version: 1.0.105

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -285,6 +285,12 @@ public class PoshiRunnerContext {
 		_readTestToggleFiles();
 	}
 
+	public static void readFiles(String[] includes, String... baseDirNames)
+		throws Exception {
+
+		_readPoshiFiles(includes, baseDirNames);
+	}
+
 	public static void setTestCaseNamespacedClassCommandName(
 		String testCaseNamespacedClassCommandName) {
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -92,6 +92,10 @@ public class PoshiRunnerContext {
 		return _filePaths.get(namespace + "." + fileName);
 	}
 
+	public static List<String> getFilePathKeys() {
+		return new ArrayList<>(_filePaths.keySet());
+	}
+
 	public static List<String> getFilePaths() {
 		return new ArrayList<>(_filePaths.values());
 	}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -52,6 +52,18 @@ public class ExecutePoshiElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
+		String executeClassName = RegexUtil.getGroup(
+			readableSyntax, "(.*?)(\\(|\\.)", 1);
+
+		String executeType = "macro";
+
+		if (PoshiElement.utilClassNames.contains(executeClassName)) {
+			executeType = "class";
+		}
+		else if (PoshiElement.functionFileNames.contains(executeClassName)) {
+			executeType = "function";
+		}
+
 		if (readableSyntax.contains("return(\n")) {
 			PoshiNode returnPoshiNode = PoshiNodeFactory.newPoshiNode(
 				this, readableSyntax);
@@ -64,29 +76,15 @@ public class ExecutePoshiElement extends PoshiElement {
 			}
 		}
 
-		String executeType = "macro";
-
 		String content = getParentheticalContent(readableSyntax);
 
 		String[] functionAttributeNames =
 			{"locator1", "locator2", "value1", "value2"};
 
-		for (String functionAttributeName : functionAttributeNames) {
-			if (content.startsWith(functionAttributeName)) {
-				executeType = "function";
-
-				break;
-			}
-		}
-
 		String executeCommandName = RegexUtil.getGroup(
 			readableSyntax, "([^\\s]*)\\(", 1);
 
 		executeCommandName = executeCommandName.replace(".", "#");
-
-		if (!executeCommandName.contains("#") && (content.length() == 0)) {
-			executeType = "function";
-		}
 
 		addAttribute(executeType, executeCommandName);
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -76,17 +76,14 @@ public class ExecutePoshiElement extends PoshiElement {
 			}
 		}
 
-		String content = getParentheticalContent(readableSyntax);
-
-		String[] functionAttributeNames =
-			{"locator1", "locator2", "value1", "value2"};
-
 		String executeCommandName = RegexUtil.getGroup(
 			readableSyntax, "([^\\s]*)\\(", 1);
 
 		executeCommandName = executeCommandName.replace(".", "#");
 
 		addAttribute(executeType, executeCommandName);
+
+		String content = getParentheticalContent(readableSyntax);
 
 		if (content.length() == 0) {
 			return;
@@ -104,6 +101,9 @@ public class ExecutePoshiElement extends PoshiElement {
 			assignment = assignment.trim();
 
 			boolean functionAttributeAdded = false;
+
+			String[] functionAttributeNames =
+				{"locator1", "locator2", "value1", "value2"};
 
 			for (String functionAttributeName : functionAttributeNames) {
 				if (assignment.startsWith(functionAttributeName)) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -322,6 +322,7 @@ public abstract class PoshiElement
 		readableSyntax = readableSyntax.trim();
 
 		if (readableSyntax.startsWith("property") ||
+			readableSyntax.startsWith("static var") ||
 			readableSyntax.startsWith("var")) {
 
 			if (readableSyntax.endsWith("\'\'\';") ||

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarPoshiElement.java
@@ -71,6 +71,14 @@ public class VarPoshiElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
+		if (readableSyntax.startsWith("static")) {
+			addAttribute("static", "true");
+
+			readableSyntax = readableSyntax.replaceFirst("static", "");
+
+			readableSyntax = readableSyntax.trim();
+		}
+
 		String name = getNameFromAssignment(readableSyntax);
 
 		addAttribute("name", name);
@@ -108,6 +116,12 @@ public class VarPoshiElement extends PoshiElement {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("\n\t");
+
+		String staticAttribute = attributeValue("static");
+
+		if (staticAttribute != null) {
+			sb.append("static ");
+		}
 
 		PoshiElement parentElement = (PoshiElement)getParent();
 
@@ -238,7 +252,9 @@ public class VarPoshiElement extends PoshiElement {
 			return false;
 		}
 
-		if (!readableSyntax.startsWith("var ")) {
+		if (!readableSyntax.startsWith("static var") &&
+			!readableSyntax.startsWith("var ")) {
+
 			return false;
 		}
 

--- a/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -97,6 +97,17 @@ public class PoshiElementFactoryTest {
 	}
 
 	@Test
+	public void testReadableMacroFormat() throws Exception {
+		PoshiElement actualElement = _getPoshiElement(
+			"FormattedReadableSyntax.macro");
+		Element expectedElement = _getDom4JElement("PoshiSyntax.macro");
+
+		_assertEqualElements(
+			actualElement, expectedElement,
+			"Readable syntax does not translate to XML.");
+	}
+
+	@Test
 	public void testReadableMacroToXML() throws Exception {
 		PoshiElement actualElement = _getPoshiElement("ReadableSyntax.macro");
 		Element expectedElement = _getDom4JElement("PoshiSyntax.macro");

--- a/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -129,7 +129,7 @@ public class PoshiElementFactoryTest {
 			String actual = Dom4JUtil.format(actualElement);
 			String expected = Dom4JUtil.format(expectedElement);
 
-			_getErrorMessage(actual, expected, errorMessage);
+			errorMessage = _getErrorMessage(actual, expected, errorMessage);
 
 			throw new Exception(errorMessage);
 		}

--- a/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.poshi.runner.elements;
 
+import com.liferay.poshi.runner.PoshiRunnerContext;
 import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.FileUtil;
 
@@ -23,12 +24,24 @@ import org.dom4j.Node;
 import org.dom4j.Text;
 import org.dom4j.util.NodeComparator;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * @author Kenji Heigel
  */
 public class PoshiElementFactoryTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		String[] poshiFileNames = {"**/*.function"};
+
+		String poshiFileDir =
+			"../poshi-runner-resources/src/main/resources/default" +
+				"/testFunctional/functions";
+
+		PoshiRunnerContext.readFiles(poshiFileNames, poshiFileDir);
+	}
 
 	@Test
 	public void testPoshiMacroToReadable() throws Exception {

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/FormattedReadableSyntax.macro
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/FormattedReadableSyntax.macro
@@ -1,0 +1,14 @@
+definition {
+	macro configureBreadcrumb {
+		SelectFrame(
+			locator1 = "IFrame#CONFIGURATION"
+		);
+	}
+
+	macro viewPG {
+		var key_breadcrumbName = "${breadcrumbName}";
+		var breadcrumbNameUppercase = "StringUtil.upperCase('${breadcrumbName}')";
+
+		AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
+	}
+}

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.testcase
@@ -8,7 +8,7 @@
 	<!--This is a multiline
 		comment.-->
 
-	<var name="userPassword" value="password" />
+	<var name="userPassword" static="true" value="password" />
 	<var name="userScreenName" value="joeblogs" />
 
 	<set-up>

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/PoshiSyntax.testcase
@@ -269,6 +269,8 @@
 
 		<execute function="Refresh" />
 
+		<execute function="Refresh#refresh" />
+
 		<execute function="Type" value1="Welcome" />
 
 		<execute function="AssertElementPresent#assertElementPresent" locator1="Home#PAGE" value1="Welcome" />

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.testcase
@@ -207,6 +207,8 @@ definition {
 
 		Refresh();
 
+		Refresh.refresh();
+
 		Type(value1 = "Welcome");
 
 		AssertElementPresent.assertElementPresent(locator1 = "Home#PAGE", value1 = "Welcome");

--- a/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.testcase
+++ b/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/elements/ReadableSyntax.testcase
@@ -10,7 +10,7 @@ definition {
 	/*This is a multiline
 		comment.*/
 
-	var userPassword = "password";
+	static var userPassword = "password";
 	var userScreenName = "joeblogs";
 
 	setUp {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40617

@christieyoo, this will add multiline support for functions calls in the poshiscript syntax. It should actually add a lot more flexibility across the board when using poshiscript, whether you want to do single/multi line function/macro calls. This will also set up the foundation for [LRQA-40754](https://issues.liferay.com/browse/LRQA-40754). 