### PR TITLE
LRQA-45601 Print out line numbers in error snippets for Poshi Script syntax errors

### DIFF
--- a/poshi-runner/bnd.bnd
+++ b/poshi-runner/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner
 Bundle-SymbolicName: com.liferay.poshi.runner
-Bundle-Version: 1.0.214
+Bundle-Version: 1.0.215

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -177,6 +177,10 @@ public class PoshiRunnerContext {
 		return getDefaultNamespace();
 	}
 
+	public static List<String> getNamespaces() {
+		return _namespaces;
+	}
+
 	public static String getOverrideClassName(String namespacedClassName) {
 		return _overrideClassNames.get(namespacedClassName);
 	}
@@ -1430,6 +1434,9 @@ public class PoshiRunnerContext {
 
 				if (fileName.endsWith(".function")) {
 					_functionFileNames.add(fileName.replace(".function", ""));
+
+					_functionFileNames.add(
+						namespace + "." + fileName.replace(".function", ""));
 				}
 			}
 		}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -14,6 +14,7 @@
 
 package com.liferay.poshi.runner.elements;
 
+import com.liferay.poshi.runner.PoshiRunnerContext;
 import com.liferay.poshi.runner.script.PoshiScriptParserException;
 import com.liferay.poshi.runner.util.RegexUtil;
 
@@ -97,7 +98,31 @@ public class ExecutePoshiElement extends PoshiElement {
 		String executeCommandName = RegexUtil.getGroup(
 			poshiScript, "([^\\s]*?)\\(", 1);
 
-		executeCommandName = executeCommandName.replace(".", "#");
+		boolean namespacedCommandName = false;
+
+		for (String namespace : PoshiRunnerContext.getNamespaces()) {
+			if (executeCommandName.startsWith(namespace + ".")) {
+				namespacedCommandName = true;
+
+				break;
+			}
+		}
+
+		if (namespacedCommandName) {
+			int index = executeCommandName.indexOf(".");
+
+			String namespace = executeCommandName.substring(0, index);
+
+			executeCommandName = executeCommandName.replace(
+				namespace + ".", "");
+
+			executeCommandName = executeCommandName.replace(".", "#");
+
+			executeCommandName = namespace + "." + executeCommandName;
+		}
+		else {
+			executeCommandName = executeCommandName.replace(".", "#");
+		}
 
 		if (fileExtension.equals("function") ||
 			isValidFunctionFileName(poshiScript)) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -72,6 +72,10 @@ public abstract class PoshiElement
 		return clone(null, poshiScript);
 	}
 
+	public int getDefaultPoshiScriptLineNumber() {
+		return getPoshiScriptLineNumber();
+	}
+
 	public String getPoshiLogDescriptor() {
 		return getPoshiScript();
 	}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiNodeFactory.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiNodeFactory.java
@@ -178,7 +178,7 @@ public abstract class PoshiNodeFactory {
 				"Data loss has occurred while parsing Poshi Script",
 				newPoshiElement);
 
-			pspe.setErrorDetails(newPoshiScript);
+			pspe.setPoshiScriptSnippet(newPoshiScript);
 
 			throw pspe;
 		}

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenPoshiElement.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenPoshiElement.java
@@ -117,10 +117,6 @@ public class ThenPoshiElement extends PoshiElement {
 		return "then";
 	}
 
-	protected int getDefaultPoshiScriptLineNumber() {
-		return super.getPoshiScriptLineNumber();
-	}
-
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String poshiScript) {
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
@@ -14,6 +14,7 @@
 
 package com.liferay.poshi.runner.script;
 
+import com.liferay.poshi.runner.elements.PoshiElement;
 import com.liferay.poshi.runner.elements.PoshiNode;
 import com.liferay.poshi.runner.util.StringUtil;
 
@@ -36,9 +37,10 @@ public class PoshiScriptParserException extends Exception {
 	public PoshiScriptParserException(String msg, PoshiNode poshiNode) {
 		super(msg);
 
-		setErrorDetails(poshiNode.getPoshiScript());
+		setErrorLineNumber(poshiNode.getPoshiScriptLineNumber());
 		setFilePath(poshiNode.getFilePath());
-		setLineNumber(poshiNode.getPoshiScriptLineNumber());
+		setPoshiScriptSnippet(poshiNode.getPoshiScript());
+		setStartingLineNumber(poshiNode.getPoshiScriptLineNumber());
 	}
 
 	public PoshiScriptParserException(
@@ -50,29 +52,30 @@ public class PoshiScriptParserException extends Exception {
 
 		String parentPoshiScript = parentPoshiNode.getPoshiScript();
 
-		setErrorDetails(parentPoshiScript);
+		parentPoshiScript = parentPoshiScript.replaceFirst("^[\\n\\r]*", "");
 
-		parentPoshiScript = parentPoshiScript.trim();
+		setPoshiScriptSnippet(parentPoshiScript);
+
+		PoshiElement parentPoshiElement = (PoshiElement)parentPoshiNode;
+
+		int startingLineNumber =
+			parentPoshiElement.getDefaultPoshiScriptLineNumber();
+
+		setStartingLineNumber(startingLineNumber);
 
 		int index = parentPoshiScript.indexOf(poshiScript.trim());
 
-		int lineNumber =
-			parentPoshiNode.getPoshiScriptLineNumber() +
-				StringUtil.count(parentPoshiScript, "\n", index);
-
-		setLineNumber(lineNumber);
+		setErrorLineNumber(
+			startingLineNumber +
+				StringUtil.count(parentPoshiScript, "\n", index));
 	}
 
-	public String getErrorDetails() {
-		return _errorDetails;
+	public int getErrorLineNumber() {
+		return _errorLineNumber;
 	}
 
 	public String getFilePath() {
 		return _filePath;
-	}
-
-	public int getLineNumber() {
-		return _lineNumber;
 	}
 
 	@Override
@@ -83,15 +86,23 @@ public class PoshiScriptParserException extends Exception {
 		sb.append(" at:\n");
 		sb.append(getFilePath());
 		sb.append(":");
-		sb.append(getLineNumber());
+		sb.append(getErrorLineNumber());
 		sb.append("\n");
-		sb.append(getErrorDetails());
+		sb.append(getPoshiScriptSnippet());
 
 		return sb.toString();
 	}
 
-	public void setErrorDetails(String errorDetails) {
-		_errorDetails = errorDetails;
+	public String getPoshiScriptSnippet() {
+		return _poshiScriptSnippet;
+	}
+
+	public int getStartingLineNumber() {
+		return _startingLineNumber;
+	}
+
+	public void setErrorLineNumber(int errorLineNumber) {
+		_errorLineNumber = errorLineNumber;
 	}
 
 	public void setFilePath(String filePath) {
@@ -100,14 +111,19 @@ public class PoshiScriptParserException extends Exception {
 		failingFilePaths.add(filePath);
 	}
 
-	public void setLineNumber(int lineNumber) {
-		_lineNumber = lineNumber;
+	public void setPoshiScriptSnippet(String poshiScriptSnippet) {
+		_poshiScriptSnippet = poshiScriptSnippet;
+	}
+
+	public void setStartingLineNumber(int startingLineNumber) {
+		_startingLineNumber = startingLineNumber;
 	}
 
 	protected static List<String> failingFilePaths = new ArrayList<>();
 
-	private String _errorDetails = "";
+	private int _errorLineNumber;
 	private String _filePath = "Unknown file";
-	private int _lineNumber;
+	private String _poshiScriptSnippet = "";
+	private int _startingLineNumber;
 
 }

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
@@ -88,7 +88,7 @@ public class PoshiScriptParserException extends Exception {
 		sb.append(":");
 		sb.append(getErrorLineNumber());
 		sb.append("\n");
-		sb.append(getPoshiScriptSnippet());
+		sb.append(createErrorSnippet());
 
 		return sb.toString();
 	}
@@ -117,6 +117,43 @@ public class PoshiScriptParserException extends Exception {
 
 	public void setStartingLineNumber(int startingLineNumber) {
 		_startingLineNumber = startingLineNumber;
+	}
+
+	protected String createErrorSnippet() {
+		StringBuilder sb = new StringBuilder();
+
+		String poshiScript = getPoshiScriptSnippet();
+
+		int startingLineNumber = getStartingLineNumber();
+
+		String lineNumberString = String.valueOf(
+			startingLineNumber + StringUtil.count(poshiScript, "\n"));
+
+		int pad = lineNumberString.length() + 2;
+
+		for (String line : poshiScript.split("\n")) {
+			StringBuilder prefix = new StringBuilder();
+
+			if (startingLineNumber == getErrorLineNumber()) {
+				prefix.append(">");
+			}
+			else {
+				prefix.append(" ");
+			}
+
+			prefix.append(" ");
+
+			prefix.append(startingLineNumber);
+
+			sb.append(String.format("%" + pad + "s", prefix.toString()));
+			sb.append(" |");
+			sb.append(line.replace("\t", "    "));
+			sb.append("\n");
+
+			startingLineNumber++;
+		}
+
+		return sb.toString();
 	}
 
 	protected static List<String> failingFilePaths = new ArrayList<>();

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/PoshiScriptParserException.java
@@ -40,7 +40,16 @@ public class PoshiScriptParserException extends Exception {
 		setErrorLineNumber(poshiNode.getPoshiScriptLineNumber());
 		setFilePath(poshiNode.getFilePath());
 		setPoshiScriptSnippet(poshiNode.getPoshiScript());
-		setStartingLineNumber(poshiNode.getPoshiScriptLineNumber());
+
+		if (poshiNode instanceof PoshiElement) {
+			PoshiElement poshiElement = (PoshiElement)poshiNode;
+
+			setStartingLineNumber(
+				poshiElement.getDefaultPoshiScriptLineNumber());
+		}
+		else {
+			poshiNode.getPoshiScriptLineNumber();
+		}
 	}
 
 	public PoshiScriptParserException(
@@ -56,10 +65,14 @@ public class PoshiScriptParserException extends Exception {
 
 		setPoshiScriptSnippet(parentPoshiScript);
 
-		PoshiElement parentPoshiElement = (PoshiElement)parentPoshiNode;
+		int startingLineNumber = parentPoshiNode.getPoshiScriptLineNumber();
 
-		int startingLineNumber =
-			parentPoshiElement.getDefaultPoshiScriptLineNumber();
+		if (parentPoshiNode instanceof PoshiElement) {
+			PoshiElement parentPoshiElement = (PoshiElement)parentPoshiNode;
+
+			startingLineNumber =
+				parentPoshiElement.getDefaultPoshiScriptLineNumber();
+		}
 
 		setStartingLineNumber(startingLineNumber);
 

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
@@ -41,7 +41,7 @@ public class UnbalancedCodeException extends PoshiScriptParserException {
 	private static String _getLine(int lineNumber, String code) {
 		String[] lines = code.split("\n");
 
-		return lines[lineNumber - 1];
+		return lines[lineNumber - 1].replace("\t", "    ");
 	}
 
 	private void _processLine(int index, String code) {

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
@@ -25,6 +25,19 @@ public class UnbalancedCodeException extends PoshiScriptParserException {
 		_processLine(index, code);
 	}
 
+	public String getErrorSnippet() {
+		return _errorSnippet;
+	}
+
+	public void setErrorSnippet(String errorSnippet) {
+		_errorSnippet = errorSnippet;
+	}
+
+	@Override
+	protected String createErrorSnippet() {
+		return getErrorSnippet();
+	}
+
 	private static String _getLine(int lineNumber, String code) {
 		String[] lines = code.split("\n");
 
@@ -69,7 +82,9 @@ public class UnbalancedCodeException extends PoshiScriptParserException {
 
 		sb.append("^");
 
-		setPoshiScriptSnippet(sb.toString());
+		setErrorSnippet(sb.toString());
 	}
+
+	private String _errorSnippet = "";
 
 }

--- a/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
+++ b/poshi-runner/src/main/java/com/liferay/poshi/runner/script/UnbalancedCodeException.java
@@ -44,7 +44,7 @@ public class UnbalancedCodeException extends PoshiScriptParserException {
 			}
 		}
 
-		setLineNumber(lineNumber);
+		setErrorLineNumber(lineNumber);
 
 		int column = 1;
 
@@ -69,7 +69,7 @@ public class UnbalancedCodeException extends PoshiScriptParserException {
 
 		sb.append("^");
 
-		setErrorDetails(sb.toString());
+		setPoshiScriptSnippet(sb.toString());
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-45601

@pyoo47, ended up just printing out the Poshi Script from the node. I thought I had already had something to use for just getting the context, but I didn't, so this will be easier and more bang for buck. 

### Before:
```
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro:9
     [exec]
     [exec] 	macro _gotoAddPGViaWCD {
     [exec] 		MouseOver.mouseOverNotVisible(locator1 = "WCD#ADD_WEB_CONTENT");
     [exec]
     [exec] 		Click(locator1 = "WCD#ADD_WEB_CONTENT");
     [exec]
     [exec] 		var key_structureName = "Basic Web Content";
     [exec]
     [exec] 		AssertClick(
     [exec] 			locator1 = "WCD#ADD_STRUCTURED_WEB_CONTENT",
     [exec] 			value1 = "Basic Web Content"
     [exec] 		)
     [exec]
     [exec] 		SelectFrame(locator1 = "IFrame#EDIT_ASSET");
     [exec] 	}
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro:1000
     [exec]
     [exec]
     [exec] 	macro expireSpecificVersionCP {
     [exec] 		WebContentNavigator.gotoEntryMenuItem(
     [exec] 			entry = "${webContentTitle}",
     [exec] 			menuItem = "View History"
     [exec] 		);
     [exec]
     [exec] 		if (isSet(webContentList)) {
     [exec] 			for (var webContentTitle : list "${webContentList}") {
     [exec] 				Check(
     [exec] 					locator1 = "WCEditWebContent#VIEW_HISTORY_VERSION_CHECKBOX",
     [exec] 					key_webContentTitle = "${webContentTitle}"
     [exec] 				);
     [exec] 			}
     [exec] 		}
     [exec] 		else {
     [exec] 			Check(
     [exec] 				locator1 = "WCEditWebContent#VIEW_HISTORY_VERSION_CHECKBOX",
     [exec] 				key_webContentTitle = "${webContentTitle}"
     [exec] 			);
     [exec] 		}
     [exec]
     [exec] 		ClickNoError(locator1 = "Icon#EXPIRE")
     [exec]
     [exec] 		AssertConfirm(value1 = "Are you sure you want to expire the selected version?");
     [exec] 	}
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/security/usecase/SecurityUsecase.testcase:20
     [exec]
     [exec] 		else {
     [exec] 			PortalSettings.tearDownAuthenticationCP()
     [exec]
     [exec] 			Page.tearDownCP();
     [exec] 		}
     [exec] Exception in thread "main" java.lang.RuntimeException: Found 3 Poshi Script parsing errors
```

### After:
```
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro:9
     [exec]    2 |    macro _gotoAddPGViaWCD {
     [exec]    3 |        MouseOver.mouseOverNotVisible(locator1 = "WCD#ADD_WEB_CONTENT");
     [exec]    4 |
     [exec]    5 |        Click(locator1 = "WCD#ADD_WEB_CONTENT");
     [exec]    6 |
     [exec]    7 |        var key_structureName = "Basic Web Content";
     [exec]    8 |
     [exec]  > 9 |        AssertClick(
     [exec]   10 |            locator1 = "WCD#ADD_STRUCTURED_WEB_CONTENT",
     [exec]   11 |            value1 = "Basic Web Content"
     [exec]   12 |        )
     [exec]   13 |
     [exec]   14 |        SelectFrame(locator1 = "IFrame#EDIT_ASSET");
     [exec]   15 |    }
     [exec]
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro:1000
     [exec]    979 |    macro expireSpecificVersionCP {
     [exec]    980 |        WebContentNavigator.gotoEntryMenuItem(
     [exec]    981 |            entry = "${webContentTitle}",
     [exec]    982 |            menuItem = "View History"
     [exec]    983 |        );
     [exec]    984 |
     [exec]    985 |        if (isSet(webContentList)) {
     [exec]    986 |            for (var webContentTitle : list "${webContentList}") {
     [exec]    987 |                Check(
     [exec]    988 |                    locator1 = "WCEditWebContent#VIEW_HISTORY_VERSION_CHECKBOX",
     [exec]    989 |                    key_webContentTitle = "${webContentTitle}"
     [exec]    990 |                );
     [exec]    991 |            }
     [exec]    992 |        }
     [exec]    993 |        else {
     [exec]    994 |            Check(
     [exec]    995 |                locator1 = "WCEditWebContent#VIEW_HISTORY_VERSION_CHECKBOX",
     [exec]    996 |                key_webContentTitle = "${webContentTitle}"
     [exec]    997 |            );
     [exec]    998 |        }
     [exec]    999 |
     [exec] > 1000 |        ClickNoError(locator1 = "Icon#EXPIRE")
     [exec]   1001 |
     [exec]   1002 |        AssertConfirm(value1 = "Are you sure you want to expire the selected version?");
     [exec]   1003 |    }
     [exec]
     [exec] Invalid Poshi Script syntax at:
     [exec] /Users/kenji/Projects/github/liferay-portal/master/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/security/usecase/SecurityUsecase.testcase:20
     [exec]   19 |        else {
     [exec] > 20 |            PortalSettings.tearDownAuthenticationCP()
     [exec]   21 |
     [exec]   22 |            Page.tearDownCP();
     [exec]   23 |        }
     [exec]
     [exec] Exception in thread "main" java.lang.RuntimeException: Found 3 Poshi Script parsing errors
     [exec] 	at com.liferay.poshi.runner.PoshiRunnerValidation.main(PoshiRunnerValidation.java:61)
```